### PR TITLE
Honour horizontal prop in exported FlatList

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -274,7 +274,7 @@ const ScrollView = forwardRef(function ScrollView({ horizontal = false, anchors,
  */
 function FlatList({ flatListRef, horizontal = false, anchors, ...props }) {
     return (React.createElement(AnchorProvider, { anchors: anchors, horizontal: horizontal },
-        React.createElement(AnchorsContext.Consumer, null, ({ registerScrollRef }) => (React.createElement(NativeFlatList, Object.assign({}, props, { ref: mergeRefs([registerScrollRef, flatListRef || null]) }))))));
+        React.createElement(AnchorsContext.Consumer, null, ({ registerScrollRef }) => (React.createElement(NativeFlatList, Object.assign({}, props, { horizontal: horizontal, ref: mergeRefs([registerScrollRef, flatListRef || null]) }))))));
 }
 function ScrollTo({ target, onPress, options, onRequestScrollTo, ...props }) {
     const { scrollTo } = useScrollTo();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -442,6 +442,7 @@ function FlatList<T = any>({
         {({ registerScrollRef }) => (
           <NativeFlatList
             {...props}
+            horizontal={horizontal}
             ref={mergeRefs([registerScrollRef, flatListRef || null])}
           />
         )}


### PR DESCRIPTION
Pass the horizontal prop from the exported FlatList component down to the underlying React Native FlatList, in the same way the exported ScrollView does. Fixes #1 